### PR TITLE
Remove unnecessary scan for hashtags

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -3,16 +3,12 @@ class Spot < ApplicationRecord
   before_create :create_tags, :cleanup_text
   after_create_commit { UpdateStatusJob.perform_later(self) unless new_today? }
 
-  def has_tags?
-    text.scan(/\B#\w+/).length > 0
-  end
-
   def cleanup_text
     self.text = text.gsub(/\B#\w+/, '')
   end
 
   def create_tags
-    self.tags = text.scan(/\B#\w+/).map{ |tag| tag.gsub('#', '') } if has_tags?
+    self.tags = text.scan(/\B#\w+/).map{ |tag| tag.gsub('#', '') }
   end
 
   private


### PR DESCRIPTION
Scanning the text when there are no hashtags and then mapping will return back an empty array, which is what we set as the default value for `tags` on spot instances anyway, so there's no need to check for hashtags in the text before extracting them out.