### PR TITLE
Feature/hangouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'redis-rack-cache'
 # Autoprefixer
 gem 'autoprefixer-rails'
 
+gem 'bitly'
+
 # Heroku
 gem 'rails_12factor', group: :production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
     autoprefixer-rails (6.3.1)
       execjs
       json
+    bitly (0.10.4)
+      httparty (>= 0.7.6)
+      multi_json (~> 1.3)
+      oauth2 (>= 0.5.0, < 2.0)
     builder (3.2.2)
     byebug (8.2.1)
     coffee-rails (4.1.1)
@@ -94,6 +98,8 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.6.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     faye-websocket (0.10.2)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -106,6 +112,10 @@ GEM
     groupdate (2.5.0)
       activesupport (>= 3)
     hiredis (0.6.1)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    httpauth (0.2.1)
     i18n (0.7.0)
     jquery-rails (4.1.0)
       rails-dom-testing (~> 1.0)
@@ -122,8 +132,15 @@ GEM
     mime-types (2.99)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    multi_json (1.11.2)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    oauth2 (0.6.1)
+      faraday (~> 0.7)
+      httpauth (~> 0.1)
+      multi_json (~> 1.3)
     pg (0.18.4)
     puma (2.15.3)
     rack (2.0.0.alpha)
@@ -198,6 +215,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
+  bitly
   byebug
   coffee-rails (~> 4.1.0)
   connection_pool

--- a/app/controllers/concerns/verify_slack_token.rb
+++ b/app/controllers/concerns/verify_slack_token.rb
@@ -1,0 +1,21 @@
+module VerifySlackToken
+  extend ActiveSupport::Concern
+  included do
+    skip_before_action :verify_authenticity_token
+    before_filter :verify_slack_token, except: [:index, :show, :awesome]
+  end
+
+  private
+  # Setup slack responder
+  def responder
+    @responder ||= Slack::Response.new(params[:text])
+  end
+
+  def slack_params
+    params.permit(:user_id, :user_name, :text, :channel_name)
+  end
+
+  def verify_slack_token
+    render nothing: true, status: :forbidden and return unless Slack::TOKENS.include?(params[:token])
+  end
+end

--- a/app/controllers/hangouts_controller.rb
+++ b/app/controllers/hangouts_controller.rb
@@ -1,6 +1,6 @@
 class HangoutsController < ApplicationController
   include VerifySlackToken
-  before_action :find_hangout, on: :create
+  before_action :find_hangout, except: :user
 
   # POST /hangouts
   def create
@@ -9,7 +9,7 @@ class HangoutsController < ApplicationController
     if @hangout.blank? and params[:text].present?
       @hangout = create_hangout
       if @hangout.save
-        render plain: t(:create_hangout, user_name: params[:user_name], url: params[:text])
+        render plain: t(:create_hangout, user_name: params[:user_name], url: @hangout.url)
       else
         render plain: "Error: #{@hangout.errors.full_messages.to_sentence}"
       end

--- a/app/controllers/hangouts_controller.rb
+++ b/app/controllers/hangouts_controller.rb
@@ -1,0 +1,52 @@
+class HangoutsController < ApplicationController
+  include VerifySlackToken
+  before_action :find_hangout, on: :create
+
+  # POST /hangouts
+  def create
+    render plain: "Command not found", status: :ok unless params[:command] == "/myhangout"
+
+    if @hangout.blank? and params[:text].present?
+      @hangout = create_hangout
+      if @hangout.save
+        render plain: t(:create_hangout, user_name: params[:user_name], url: params[:text])
+      else
+        render plain: "Error: #{@hangout.errors.full_messages.to_sentence}"
+      end
+    elsif @hangout.present? and params[:text].present?
+      @hangout.url = params[:text]
+      if @hangout.save
+        render plain: t(:update_hangout, user_name: params[:user_name], url: @hangout.url)
+      else
+        render plain: "Error: #{@hangout.errors.full_messages.to_sentence}"
+      end
+    elsif @hangout.present? and params[:text].empty?
+      render plain: t(:your_hangout, user_name: params[:user_name], url: @hangout.url)
+    end
+  end
+
+  # POST /hangouts/user
+  def user
+    render plain: 'Enter a username: `/hangoutwith [username]`' and return if params[:text].empty?
+
+    @hangout = Hangout.find_by(user_name: params[:text].gsub('@', ''))
+    if @hangout.blank? and params[:command] == "/hangoutwith"
+      render plain: t(:no_user_hangout, name: params[:text])
+    else
+      render plain: t(:user_hangout, name: @hangout.user_name.capitalize, url: @hangout.url)
+    end
+  end
+
+  private
+
+  def create_hangout
+    Hangout.create(url: params[:text], user_id: params[:user_id], user_name: params[:user_name])
+  end
+
+  def find_hangout
+    @hangout = Hangout.find_by(user_id: params[:user_id])
+    if @hangout.blank? and params[:text].empty?
+      render plain: t(:no_hangout, user_name: params[:user_name], url: params[:text])
+    end
+  end
+end

--- a/app/models/hangout.rb
+++ b/app/models/hangout.rb
@@ -1,4 +1,11 @@
 class Hangout < ApplicationRecord
   validates :url, presence: true
   validates :url, format: { with: URI.regexp, message: "Enter a valid hangout url" }
+  before_save :shorten_url
+
+  private
+  def shorten_url
+    b = Bitly.client.shorten(self.url)
+    self.url = b.short_url
+  end
 end

--- a/app/models/hangout.rb
+++ b/app/models/hangout.rb
@@ -1,0 +1,4 @@
+class Hangout < ApplicationRecord
+  validates :url, presence: true
+  validates :url, format: { with: URI.regexp, message: "Enter a valid hangout url" }
+end

--- a/config/initializers/bitly.rb
+++ b/config/initializers/bitly.rb
@@ -1,0 +1,6 @@
+Bitly.use_api_version_3
+
+Bitly.configure do |config|
+  config.api_version = 3
+  config.access_token = ENV['BITLY_TOKEN']
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,8 +3,8 @@
 en:
   no_hangout: "@%{user_name}: You have no associated hangout present.
   Please create one by passing a hangout link like so: `/myhangout [google_hangout_link]`"
-  update_hangout:  "@%{user_name}: Your permanent hangout link: %{url} is updated"
-  create_hangout: "@%{user_name}: Your hangout link: %{url} is added as your permanenent hangout.
+  update_hangout:  "@%{user_name}: Your permanent hangout short url: %{url} is updated"
+  create_hangout: "@%{user_name}: Your hangout short url: %{url} is added as your permanenent hangout.
   If you change this link, simply re-run the previous command with a new link"
   your_hangout: "@%{user_name}: Your permanent hangout link is: %{url}"
   user_hangout: "%{name}: permanent hangout url is: %{url}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,6 @@ en:
   update_hangout:  "@%{user_name}: Your permanent hangout short url: %{url} is updated"
   create_hangout: "@%{user_name}: Your hangout short url: %{url} is added as your permanenent hangout.
   If you change this link, simply re-run the previous command with a new link"
-  your_hangout: "@%{user_name}: Your permanent hangout link is: %{url}"
-  user_hangout: "%{name}: permanent hangout url is: %{url}"
+  your_hangout: "@%{user_name}: Your permanent hangout link is: %{url}. Click the link to join"
+  user_hangout: "%{name}: permanent hangout url is: %{url}. Click the link to join"
   no_user_hangout: "%{name}: has no associated hangout url present or `%{name}` username not present."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,11 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# Default translations
 
 en:
-  hello: "Hello world"
+  no_hangout: "@%{user_name}: You have no associated hangout present.
+  Please create one by passing a hangout link like so: `/myhangout [google_hangout_link]`"
+  update_hangout:  "@%{user_name}: Your permanent hangout link: %{url} is updated"
+  create_hangout: "@%{user_name}: Your hangout link: %{url} is added as your permanenent hangout.
+  If you change this link, simply re-run the previous command with a new link"
+  your_hangout: "@%{user_name}: Your permanent hangout link is: %{url}"
+  user_hangout: "%{name}: permanent hangout url is: %{url}"
+  no_user_hangout: "%{name}: has no associated hangout url present or `%{name}` username not present."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,13 @@ Rails.application.routes.draw do
       get '/hall-of-fame', to: 'spots#awesome', as: :awesome
     end
   end
+
+  resources :hangouts, only: :create do
+    collection do
+      post :user
+    end
+  end
+
   # Serve websocket cable requests in-process
   mount ActionCable.server => '/cable'
 end

--- a/db/migrate/20160128151502_create_hangouts.rb
+++ b/db/migrate/20160128151502_create_hangouts.rb
@@ -1,0 +1,11 @@
+class CreateHangouts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :hangouts do |t|
+      t.string :url
+      t.string :user_name
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160120045404) do
+ActiveRecord::Schema.define(version: 20160128151502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "hangouts", force: :cascade do |t|
+    t.string   "url"
+    t.string   "user_name"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "spots", force: :cascade do |t|
     t.text     "text"


### PR DESCRIPTION
Add a feature to support hangout link addition for a team member. At the moment, we usually share hangout links manually or start hangout using ```/hangout``` command from Slack, but it's inefficient as it involves extra steps *(inviting people, sharing links)* each time a hangout is created. @ohenrik had introduced something called permanent hangout - a hangout event that expires in far future, which we both tried out and worked great for us, but the problem was storing and retrieving this link efficiently. 
So, I have added this feature to spot hyper where a hangout link can be saved, updated and retrieved by typing these two commands right from your slack channel. You create and save url once and then just use the handy ```/myhangout``` command to retrieve either yours or a team members hangout url to join: 

### Usage
```bash
/myhangout [google_hangout_link]`  # To update or Add a new one
# Example: /myhangout http://bit.ly/1OZPgbY

/myhangout # To fetch the stored value

/hangoutwith [username]
# Example: /hangoutwith @gaurav
```

What you all think? rooms.hyper.no has introduced something similar, but it's limited to number of rooms. Keeping permanent hangouts will enable us to efficiently connect on hangout without hiccups - ```like "where is the link?", "I see a cat instead of you"?```
